### PR TITLE
Memo 086: .gitignore hygiene (.memo/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ ai
 coverage
 .env
 *.env
+
+# Memo strategy docs (project-level, never in repo)
+.memo/


### PR DESCRIPTION
Closes #77

- .gitignore: ignore .memo/ strategy docs
- No version bump, no release (core schema format unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)